### PR TITLE
fix(audit-ci): Remove redundant `-c` flag

### DIFF
--- a/packages/scripts/docs/audit.md
+++ b/packages/scripts/docs/audit.md
@@ -6,7 +6,7 @@ Performs static dependency analysis
 
 The following checks are performed when this command is invoked.
 
-- ## audit-ci -h -c
+- ## audit-ci -h
 
   ### Purpose
 

--- a/packages/scripts/src/commands/audit/execute.ts
+++ b/packages/scripts/src/commands/audit/execute.ts
@@ -18,7 +18,7 @@ export async function execute(options: AuditCommandOptions): Promise<number> {
 	const runs: Array<RunArg | RunArg[]> = []
 	runs.push([
 		// Audit CVEs
-		{ exec: 'audit-ci', args: ['-h', '-c'] },
+		{ exec: 'audit-ci', args: ['-h'] },
 
 		// Check Licenses
 		{ exec: 'license-to-fail', args: [licenseConfig] },


### PR DESCRIPTION
The `-h` flag ensures that any high or critical CVEs exit with code >=1.

> Note: this is one of two concurrent pull requests for `audit-ci` (the other being https://github.com/microsoft/essex-alpha-build-infra/pull/18). Only one should be accepted depending on the desired behaviour of the dependency since the solutions are mutually exclusive. My personal preference is to use the `.audit-ci.json` configuration file rather than using the arguments, so this PR should be closed if the other PR is accepted.